### PR TITLE
Integrate Gemini 1.5 Flash translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 `doclingo` is a TypeScript CLI that translates technical documentation through Gemini. It reads Markdown from a file path or stdin and writes the translated Markdown directly to stdout so it can be piped into other tools without extra logs.
 
-> ⚠️ The Gemini API integration is coming next. For now the CLI validates inputs, language metadata, and prompt construction, so validation commands will echo the original Markdown.
-
 ## Requirements
 
 - Node.js 24 LTS (Krypton) or newer
@@ -59,4 +57,4 @@ After running `npm run build` and `npm link`, verify the following commands with
 - `doclingo zh-TW api-doc-en.md > api-doc-zh-tw.md`
 - `doclingo en api-doc-ja.md > api-doc-en.md`
 
-Each command should exit successfully without emitting extra stdout noise beyond the translated Markdown (currently the original Markdown until the Gemini call is added).
+Each command should exit successfully without emitting extra stdout noise beyond the translated Markdown returned by Gemini.


### PR DESCRIPTION
## Summary
- add a real Gemini API client that posts the generated prompt and returns the translated Markdown
- surface API failures and empty responses as CLI errors with non-zero exits
- update README to remove the temporary warning about echoing original Markdown

## Testing
- npm run build
- env GEMINI_API_KEY=dummy node dist/cli.js ja README.md | head -n 3 (verifies error surface for invalid key)

Closes #14

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> CLI now calls Gemini 1.5 Flash to return translated Markdown, with robust API error handling; README updated to reflect real translation output.
> 
> - **CLI**:
>   - Add `callGemini(prompt)` to invoke `gemini-1.5-flash` via Google Generative Language API, including request payload construction and API key header.
>   - Handle non-OK responses and empty outputs with `CliError`, preserving non-zero exits.
>   - Replace echo behavior in `main` with real translation: build prompt via `buildTranslationPrompt(...)`, call `callGemini`, and write the translation to stdout.
> - **Docs**:
>   - Update `README.md` to remove temporary echo warning and state that stdout contains translated Markdown from Gemini.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eedbab3aa6350407b8e100413a88c19ab33c4058. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->