### PR TITLE
Add configurable Gemini model selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ doclingo zh-TW api-doc-en.md > api-doc-zh-tw.md
 
 # Back to English
 doclingo en api-doc-ja.md > api-doc-en.md
+
+# Override model via CLI flag
+doclingo ja api-doc-en.md --model gemini-2.5-flash
 ```
 
 ## Validation checklist

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -191,10 +191,16 @@ const handleError = (error: unknown): never => {
  * CLI entry point. Validates configuration, gathers input, and (temporarily)
  * echoes it until the Gemini integration is added.
  */
-const DEFAULT_GEMINI_MODEL =
-  "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent";
+const DEFAULT_GEMINI_MODEL_ID = "gemini-2.5-flash-lite";
 
-const getModelEndpoint = (cliModelOverride?: string): string => {
+const buildModelEndpoint = (modelId: string): string => {
+  if (modelId.startsWith("http://") || modelId.startsWith("https://")) {
+    return modelId;
+  }
+  return `https://generativelanguage.googleapis.com/v1beta/models/${modelId}:generateContent`;
+};
+
+const resolveModelId = (cliModelOverride?: string): string => {
   const cliModel = cliModelOverride?.trim();
   if (cliModel === "") {
     throw new CliError("Model id cannot be empty.");
@@ -211,7 +217,7 @@ const getModelEndpoint = (cliModelOverride?: string): string => {
     return envModel;
   }
 
-  return DEFAULT_GEMINI_MODEL;
+  return DEFAULT_GEMINI_MODEL_ID;
 };
 
 const callGemini = async (
@@ -219,7 +225,8 @@ const callGemini = async (
   cliModelOverride?: string
 ): Promise<string> => {
   const apiKey = ensureApiKey();
-  const modelEndpoint = getModelEndpoint(cliModelOverride);
+  const modelId = resolveModelId(cliModelOverride);
+  const modelEndpoint = buildModelEndpoint(modelId);
   const response = await fetch(modelEndpoint, {
     method: "POST",
     headers: {
@@ -264,18 +271,46 @@ const callGemini = async (
   return translatedText;
 };
 
+const parseCliArgs = (
+  argv: string[]
+): { positional: string[]; modelOverride?: string } => {
+  const positional: string[] = [];
+  let modelOverride: string | undefined;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+
+    if (arg === "--model") {
+      const value = argv[i + 1];
+      if (!value || value.startsWith("--")) {
+        throw new CliError("`--model` flag requires a model id value.");
+      }
+      modelOverride = value;
+      i += 1;
+      continue;
+    }
+
+    if (arg.startsWith("--model=")) {
+      const value = arg.slice("--model=".length);
+      if (!value.trim()) {
+        throw new CliError("`--model` flag requires a model id value.");
+      }
+      modelOverride = value;
+      continue;
+    }
+
+    positional.push(arg);
+  }
+
+  return { positional, modelOverride };
+};
+
 const main = async (): Promise<void> => {
   ensureApiKey();
 
   const args = process.argv.slice(2);
-  const modelFlagIndex = args.indexOf("--model");
-
-  const [langArg, filePath] =
-    modelFlagIndex >= 0
-      ? args.filter(
-          (_, index) => index !== modelFlagIndex && index !== modelFlagIndex + 1
-        )
-      : args;
+  const { positional, modelOverride } = parseCliArgs(args);
+  const [langArg, filePath] = positional;
 
   const targetLanguage = ensureTargetLanguage(langArg);
   const languageMetadata = resolveLanguageMetadata(targetLanguage);
@@ -283,8 +318,6 @@ const main = async (): Promise<void> => {
   const input = ensureInputContent(rawInput);
 
   const prompt = buildTranslationPrompt(languageMetadata, input);
-  const modelOverride =
-    modelFlagIndex >= 0 ? args[modelFlagIndex + 1] : undefined;
   const translation = await callGemini(prompt, modelOverride);
   process.stdout.write(translation);
 };


### PR DESCRIPTION
## Summary
- allow overriding the Gemini model via `--model` CLI flag or `DOCLINGO_MODEL` env var
- keep `gemini-2.5-flash-lite` as the default when no overrides are provided
- document the new options in the README

## Testing
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for model override via `--model` CLI flag or `DOCLINGO_MODEL` env var, letting users choose the AI model used for translations and fall back to a default when unspecified.

* **Documentation**
  * Updated README with a new "Optional model override" section and an example showing how to override the model via the CLI.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->