### PR TITLE
Add translation style presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ It’s designed for engineers who prefer command-line workflows or can’t rely 
   - CLI flag: `--model gemini-2.5-flash`
   - Env variable: `DOCLINGO_MODEL=gemini-2.5-flash`
   - Defaults to `gemini-2.5-flash-lite`
+- Optional style preset:
+  - CLI flag: `--preset docs` / `--preset casual`
+  - Env variable: `DOCLINGO_PRESET=docs`
+  - Defaults to `technical`
 
 ## Setup
 
@@ -65,6 +69,8 @@ cat file.md | doclingo <lang>
 # Japanese
 doclingo ja api-doc-en.md > api-doc-ja.md
 cat api-doc-en.md | doclingo ja > api-doc-ja.md
+# Switch to the docs preset for user-friendly tone
+doclingo ja api-doc-en.md --preset docs
 
 # Spanish
 doclingo es api-doc-en.md > api-doc-es.md
@@ -94,3 +100,13 @@ After running `npm run build` and `npm link`, verify the following commands with
 - `doclingo en api-doc-ja.md > api-doc-en.md`
 
 Each command should exit successfully without emitting extra stdout noise beyond the translated Markdown returned by Gemini.
+
+## Style presets
+
+| Preset    | Description                                                              |
+| --------- | ------------------------------------------------------------------------ |
+| technical | Precise, concise engineer-facing docs. (default)                         |
+| docs      | Clear, user-focused tone for developer guides and public docs.           |
+| casual    | More relaxed, conversational tone for internal notes or blog-style docs. |
+
+Use `--preset <name>` or set `DOCLINGO_PRESET=<name>` to switch presets.


### PR DESCRIPTION
## Summary
- introduce style presets (technical/docs/casual) and resolve them via CLI flag or `DOCLINGO_PRESET`
- inject preset-specific instructions into the Gemini prompt
- update README with preset descriptions and usage examples

## Testing
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added style preset selection for translation output. Users can now choose from technical, docs, or casual presets via the new `--preset` CLI flag or `DOCLINGO_PRESET` environment variable to customize translation style.

* **Documentation**
  * Updated README with usage examples and a new "Style presets" section detailing available preset options and how to switch between them.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->