### PR TITLE
Add debug and inspection options

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,11 +113,11 @@ Use `--preset <name>` or set `DOCLINGO_PRESET=<name>` to switch presets.
 
 ## Debug & inspection
 
-| Flag            | Description                                                                                         |
-| --------------- | --------------------------------------------------------------------------------------------------- |
-| `--print-prompt` | Print the full prompt that will be sent to Gemini (stderr) before making the API call.               |
-| `--dry-run`       | Output the prompt to stdout and exit without calling Gemini. Useful for pipeline testing.          |
-| `--verbose`       | Emit status messages (model in use, request/response) and any available token usage to stderr.     |
+| Flag             | Description                                                                                    |
+| ---------------- | ---------------------------------------------------------------------------------------------- |
+| `--print-prompt` | Print the full prompt that will be sent to Gemini (stderr) before making the API call.         |
+| `--dry-run`      | Output the prompt to stdout and exit without calling Gemini. Useful for pipeline testing.      |
+| `--verbose`      | Emit status messages (model in use, request/response) and any available token usage to stderr. |
 
 Examples:
 

--- a/README.md
+++ b/README.md
@@ -110,3 +110,24 @@ Each command should exit successfully without emitting extra stdout noise beyond
 | casual    | More relaxed, conversational tone for internal notes or blog-style docs. |
 
 Use `--preset <name>` or set `DOCLINGO_PRESET=<name>` to switch presets.
+
+## Debug & inspection
+
+| Flag            | Description                                                                                         |
+| --------------- | --------------------------------------------------------------------------------------------------- |
+| `--print-prompt` | Print the full prompt that will be sent to Gemini (stderr) before making the API call.               |
+| `--dry-run`       | Output the prompt to stdout and exit without calling Gemini. Useful for pipeline testing.          |
+| `--verbose`       | Emit status messages (model in use, request/response) and any available token usage to stderr.     |
+
+Examples:
+
+```bash
+# Inspect prompt only
+doclingo ja api-doc-en.md --dry-run
+
+# See prompt but still call Gemini
+doclingo ja api-doc-en.md --print-prompt
+
+# Verbose mode with custom model and preset
+doclingo ja api-doc-en.md --verbose --model gemini-2.5-flash --preset docs
+```


### PR DESCRIPTION
## Summary
- add `--print-prompt`, `--dry-run`, and `--verbose` flags plus corresponding env vars (`DOCLINGO_PRESET` reuse, no new envs required)
- log prompts/status/usage metadata to stderr as appropriate while keeping translations on stdout
- document the new debug options in README

## Testing
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --print-prompt flag to inspect prompts before API calls
  * Added --dry-run flag to preview output without making API calls
  * Added --verbose flag for detailed diagnostics and usage information

* **Documentation**
  * Added "Debug & inspection" guide describing the new flags with examples

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->